### PR TITLE
feat: support bucket encryption configuration

### DIFF
--- a/main/obs_go_sample.go
+++ b/main/obs_go_sample.go
@@ -834,6 +834,59 @@ func getBucketNotification() {
 	}
 }
 
+func setBucketEncryption() {
+	input := &obs.SetBucketEncryptionInput{}
+	input.Bucket = bucketName
+
+	output, err := getObsClient().SetBucketEncryption(input)
+	if err == nil {
+		fmt.Printf("StatusCode:%d, RequestId:%s\n", output.StatusCode, output.RequestId)
+	} else {
+		if obsError, ok := err.(obs.ObsError); ok {
+			fmt.Println(obsError.StatusCode)
+			fmt.Println(obsError.Code)
+			fmt.Println(obsError.Message)
+		} else {
+			fmt.Println(err)
+		}
+	}
+}
+
+func getBucketEncryption() {
+	output, err := getObsClient().GetBucketEncryption(bucketName)
+	if err == nil {
+		fmt.Printf("StatusCode:%d, RequestId:%s\n", output.StatusCode, output.RequestId)
+		if output.KMSMasterKeyID == "" {
+			fmt.Printf("KMSMasterKeyID: default master key.\n")
+		} else {
+			fmt.Printf("KMSMasterKeyID: %s\n", output.KMSMasterKeyID)
+		}
+	} else {
+		if obsError, ok := err.(obs.ObsError); ok {
+			fmt.Println(obsError.StatusCode)
+			fmt.Println(obsError.Code)
+			fmt.Println(obsError.Message)
+		} else {
+			fmt.Println(err)
+		}
+	}
+}
+
+func deleteBucketEncryption() {
+	output, err := getObsClient().DeleteBucketEncryption(bucketName)
+	if err == nil {
+		fmt.Printf("StatusCode:%d, RequestId:%s\n", output.StatusCode, output.RequestId)
+	} else {
+		if obsError, ok := err.(obs.ObsError); ok {
+			fmt.Println(obsError.StatusCode)
+			fmt.Println(obsError.Code)
+			fmt.Println(obsError.Message)
+		} else {
+			fmt.Println(err)
+		}
+	}
+}
+
 func listMultipartUploads() {
 	input := &obs.ListMultipartUploadsInput{}
 	input.Bucket = bucketName
@@ -1312,7 +1365,6 @@ func main() {
 	//	obs.FlushLog()
 	//	setBucketStoragePolicy()
 	//	getBucketStoragePolicy()
-	//	deleteBucket()
 	//  listObjects()
 	//  listVersions()
 	//  listMultipartUploads()
@@ -1345,6 +1397,9 @@ func main() {
 	//  deleteBucketTagging()
 	//  setBucketNotification()
 	//  getBucketNotification()
+	//  setBucketEncryption()
+	//  getBucketEncryption()
+	//  deleteBucketEncryption()
 
 	//---- object related APIs ----
 	//  deleteObject()
@@ -1363,4 +1418,6 @@ func main() {
 	//  putFile()
 	//  getObjectMetadata()
 	//  getObject()
+
+	// deleteBucket()
 }

--- a/main/obs_go_sample.go
+++ b/main/obs_go_sample.go
@@ -837,6 +837,7 @@ func getBucketNotification() {
 func setBucketEncryption() {
 	input := &obs.SetBucketEncryptionInput{}
 	input.Bucket = bucketName
+	input.SSEAlgorithm = obs.DEFAULT_SSE_KMS_ENCRYPTION
 
 	output, err := getObsClient().SetBucketEncryption(input)
 	if err == nil {

--- a/obs/client.go
+++ b/obs/client.go
@@ -662,6 +662,45 @@ func (obsClient ObsClient) DeleteBucketLifecycleConfiguration(bucketName string,
 	return
 }
 
+// SetBucketEncryption sets the default server-side encryption for a bucket.
+//
+// You can use this API to create or update the default server-side encryption for a bucket.
+func (obsClient ObsClient) SetBucketEncryption(input *SetBucketEncryptionInput, extensions ...extensionOptions) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketEncryptionInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketEncryption", HTTP_PUT, input.Bucket, input, output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+// GetBucketEncryption gets the encryption configuration of a bucket.
+//
+// You can use this API to obtain obtain the encryption configuration of a bucket.
+func (obsClient ObsClient) GetBucketEncryption(bucketName string, extensions ...extensionOptions) (output *GetBucketEncryptionOutput, err error) {
+	output = &GetBucketEncryptionOutput{}
+	err = obsClient.doActionWithBucket("GetBucketEncryption", HTTP_GET, bucketName, newSubResourceSerial(SubResourceEncryption), output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+// DeleteBucketEncryption deletes the encryption configuration of a bucket.
+//
+// You can use this API to delete the encryption configuration of a bucket.
+func (obsClient ObsClient) DeleteBucketEncryption(bucketName string, extensions ...extensionOptions) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("DeleteBucketEncryption", HTTP_DELETE, bucketName, newSubResourceSerial(SubResourceEncryption), output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
 // SetBucketTagging sets bucket tags.
 //
 // You can use this API to set bucket tags.

--- a/obs/const.go
+++ b/obs/const.go
@@ -255,6 +255,7 @@ var (
 		"delete":                       true,
 		"cors":                         true,
 		"restore":                      true,
+		"encryption":                   true,
 		"tagging":                      true,
 		"append":                       true,
 		"position":                     true,
@@ -706,6 +707,9 @@ const (
 
 	// SubResourceNotification subResource value: notification
 	SubResourceNotification SubResourceType = "notification"
+
+	// SubResourceEncryption subResource value: encryption
+	SubResourceEncryption SubResourceType = "encryption"
 
 	// SubResourceTagging subResource value: tagging
 	SubResourceTagging SubResourceType = "tagging"

--- a/obs/convert.go
+++ b/obs/convert.go
@@ -406,6 +406,31 @@ func ConvertLifecyleConfigurationToXml(input BucketLifecyleConfiguration, return
 	return
 }
 
+// ConvertEncryptionConfigurationToXml converts BucketEncryptionConfiguration value to XML data and returns it
+func ConvertEncryptionConfigurationToXml(input BucketEncryptionConfiguration, returnMd5 bool, isObs bool) (data string, md5 string) {
+	xml := make([]string, 0, 5)
+	xml = append(xml, "<ServerSideEncryptionConfiguration><Rule><ApplyServerSideEncryptionByDefault>")
+
+	algorithm := XmlTranscoding(input.SSEAlgorithm)
+	xml = append(xml, fmt.Sprintf("<SSEAlgorithm>%s</SSEAlgorithm>", algorithm))
+
+	if input.KMSMasterKeyID != "" {
+		kmsKeyID := XmlTranscoding(input.KMSMasterKeyID)
+		xml = append(xml, fmt.Sprintf("<KMSMasterKeyID>%s</KMSMasterKeyID>", kmsKeyID))
+	}
+	if input.ProjectID != "" {
+		projectID := XmlTranscoding(input.ProjectID)
+		xml = append(xml, fmt.Sprintf("<ProjectID>%s</ProjectID>", projectID))
+	}
+
+	xml = append(xml, "</ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>")
+	data = strings.Join(xml, "")
+	if returnMd5 {
+		md5 = Base64Md5([]byte(data))
+	}
+	return
+}
+
 func converntFilterRulesToXML(filterRules []FilterRule, isObs bool) string {
 	if length := len(filterRules); length > 0 {
 		xml := make([]string, 0, length*4)

--- a/obs/model.go
+++ b/obs/model.go
@@ -612,6 +612,26 @@ type GetBucketLifecycleConfigurationOutput struct {
 	BucketLifecyleConfiguration
 }
 
+// BucketEncryptionConfiguration defines the bucket encryption configuration
+type BucketEncryptionConfiguration struct {
+	XMLName        xml.Name `xml:"ServerSideEncryptionConfiguration"`
+	SSEAlgorithm   string   `xml:"Rule>ApplyServerSideEncryptionByDefault>SSEAlgorithm"`
+	KMSMasterKeyID string   `xml:"Rule>ApplyServerSideEncryptionByDefault>KMSMasterKeyID,omitempty"`
+	ProjectID      string   `xml:"Rule>ApplyServerSideEncryptionByDefault>ProjectID,omitempty"`
+}
+
+// SetBucketEncryptionInput is the input parameter of SetBucketEncryption function
+type SetBucketEncryptionInput struct {
+	Bucket string `xml:"-"`
+	BucketEncryptionConfiguration
+}
+
+// GetBucketEncryptionOutput is the result of GetBucketEncryption function
+type GetBucketEncryptionOutput struct {
+	BaseModel
+	BucketEncryptionConfiguration
+}
+
 // Tag defines tag property in BucketTagging
 type Tag struct {
 	XMLName xml.Name `xml:"Tag"`

--- a/obs/trait.go
+++ b/obs/trait.go
@@ -335,6 +335,16 @@ func (input SetBucketLifecycleConfigurationInput) trans(isObs bool) (params map[
 	return
 }
 
+func (input SetBucketEncryptionInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	algorithm := DEFAULT_SSE_KMS_ENCRYPTION
+	if isObs {
+		algorithm = DEFAULT_SSE_KMS_ENCRYPTION_OBS
+	}
+	input.SSEAlgorithm = algorithm
+
+	return trans(SubResourceEncryption, input)
+}
+
 func (input SetBucketTaggingInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
 	params = map[string]string{string(SubResourceTagging): ""}
 	data, md5, err := ConvertRequestToIoReaderV2(input)

--- a/obs/trait.go
+++ b/obs/trait.go
@@ -336,13 +336,9 @@ func (input SetBucketLifecycleConfigurationInput) trans(isObs bool) (params map[
 }
 
 func (input SetBucketEncryptionInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
-	algorithm := DEFAULT_SSE_KMS_ENCRYPTION
-	if isObs {
-		algorithm = DEFAULT_SSE_KMS_ENCRYPTION_OBS
-	}
-	input.SSEAlgorithm = algorithm
-
-	return trans(SubResourceEncryption, input)
+	params = map[string]string{string(SubResourceEncryption): ""}
+	data, _ = ConvertEncryptionConfigurationToXml(input.BucketEncryptionConfiguration, false, isObs)
+	return
 }
 
 func (input SetBucketTaggingInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {


### PR DESCRIPTION
we can create or update the default server-side encryption for a bucket with SetBucketEncryption;
we can get the encryption configuration of a bucket with GetBucketEncryption;
we can delete the encryption configuration of a bucket with DeleteBucketEncryption;

Signed-off-by: ShiChangkuo <shichangkuo90@gmail.com>

the testing result in obs_go_sample as follows:
```
StatusCode:200, RequestId:00000179EFA1DCBA411B4108489162D9
StatusCode:200, RequestId:00000179EFA1DD0C411B41F99B19C830
KMSMasterKeyID: default master key.
StatusCode:204, RequestId:00000179EFA1DD3F411B425E0E589DD1
```