### PR TITLE
Add AvailableZone field into GetBucketMetadataOutput

### DIFF
--- a/obs/convert.go
+++ b/obs/convert.go
@@ -705,6 +705,9 @@ func ParseGetBucketMetadataOutput(output *GetBucketMetadataOutput) {
 	if ret, ok := output.ResponseHeaders[HEADER_EPID_HEADERS]; ok {
 		output.Epid = ret[0]
 	}
+	if ret, ok := output.ResponseHeaders[HEADER_AZ_REDUNDANCY]; ok {
+		output.AvailableZone = ret[0]
+	}
 	if ret, ok := output.ResponseHeaders[headerFSFileInterface]; ok {
 		output.FSStatus = parseStringToFSStatusType(ret[0])
 	} else {

--- a/obs/model.go
+++ b/obs/model.go
@@ -531,6 +531,7 @@ type GetBucketMetadataOutput struct {
 	MaxAgeSeconds int
 	ExposeHeader  string
 	Epid          string
+	AvailableZone string
 	FSStatus      FSStatusType
 }
 


### PR DESCRIPTION
Hi Team,

now, we can enable the multi-az mode by setting `CreateBucketInput.AvailableZone = "3az"`, but we can not get it from GetBucketMetadataOutput directly.

This PR add a new field named `AvailableZone` in GetBucketMetadataOutput, then we can get the multi-az mode with GetBucketMetadata function.