### PR TITLE
feat: support range params in the policy

### DIFF
--- a/obs/model_other.go
+++ b/obs/model_other.go
@@ -34,12 +34,20 @@ type CreateSignedUrlOutput struct {
 	ActualSignedRequestHeaders http.Header
 }
 
+// ConditionRange the specifying ranges in the conditions
+type ConditionRange struct {
+	RangeName string
+	Lower     int64
+	Upper     int64
+}
+
 // CreateBrowserBasedSignatureInput is the input parameter of CreateBrowserBasedSignature function.
 type CreateBrowserBasedSignatureInput struct {
-	Bucket     string
-	Key        string
-	Expires    int
-	FormParams map[string]string
+	Bucket      string
+	Key         string
+	Expires     int
+	FormParams  map[string]string
+	RangeParams []ConditionRange
 }
 
 // CreateBrowserBasedSignatureOutput is the result of CreateBrowserBasedSignature function.

--- a/obs/temporary_other.go
+++ b/obs/temporary_other.go
@@ -93,6 +93,10 @@ func (obsClient ObsClient) CreateBrowserBasedSignature(input *CreateBrowserBased
 		originPolicySlice = append(originPolicySlice, "[\"starts-with\", \"$key\", \"\"],")
 	}
 
+	for _, v := range input.RangeParams {
+		originPolicySlice = append(originPolicySlice, fmt.Sprintf("[\"%s\", %d, %d],", v.RangeName, v.Lower, v.Upper))
+	}
+
 	originPolicySlice = append(originPolicySlice, "]}")
 
 	originPolicy := strings.Join(originPolicySlice, "")


### PR DESCRIPTION
# Add support for content-length-range in CreateBrowserBasedSignature

## Background
The current implementation of `CreateBrowserBasedSignature` doesn't support specifying upload size limits in the policy. The `content-length-range` condition is a critical feature for controlling the size of uploaded objects, but it cannot be added directly as a `map[string]string` using the existing method.

## Proposal
This pull request implements support for the `content-length-range` condition as described in the OBS API documentation:
<https://support.huaweicloud.com/api-obs/obs_04_0012.html>

## Changes
1. Added a new `ConditionRange` struct to represent range conditions:
```go
type ConditionRange struct {
    RangeName string
    Lower     int64
    Upper     int64
}
```

2. Modified the CreateBrowserBasedSignatureInput struct to include a slice of ConditionRange:
```go
type CreateBrowserBasedSignatureInput struct {
    // ... existing fields
    RangeParams []ConditionRange
}
  ```

## Usage
Users can now specify upload size limits when calling `CreateBrowserBasedSignature`:

```go
input := &CreateBrowserBasedSignatureInput{
    Bucket:     "your-bucket",
    Key:        "your-key",
    Expires:    300,
    FormParams: map[string]string{"acl": "public-read"},
    RangeParams: []ConditionRange{
        {
            RangeName: "content-length-range",
            Lower:     1048576,  // 1MB
            Upper:     10485760, // 10MB
        },
    },
}

output, err := obsClient.CreateBrowserBasedSignature(input)
```