### PR TITLE
fix custom domain canonicalizedURL

### DIFF
--- a/obs/conf.go
+++ b/obs/conf.go
@@ -430,7 +430,7 @@ func (conf *config) prepareBaseURL(bucketName string) (requestURL string, canoni
 		if conf.signature == "v4" {
 			canonicalizedURL = "/"
 		} else {
-			canonicalizedURL = "/" + urlHolder.host + "/"
+			canonicalizedURL = "/" + bucketName + "/"
 		}
 	} else {
 		if bucketName == "" {


### PR DESCRIPTION
function `conf.prepareBaseURL` should append bucket name not host  when use custom domain